### PR TITLE
docs: daily-engine integration pointer

### DIFF
--- a/docs/DAILY-ENGINE-INTEGRATION.md
+++ b/docs/DAILY-ENGINE-INTEGRATION.md
@@ -1,0 +1,32 @@
+# Daily-engine integration — the plan generator behind the coach surface
+
+`organvm/daily-engine` (private) is a deterministic training/day engine whose
+every card is verified by a suite of checked invariants (pain gates on every
+card, literal instructions, computed durations, no-repeat rules,
+evidence-gated progression) before it renders. This interface is the
+partner-facing surface; the engine is the machine that can generate what the
+surface delivers.
+
+## The fit
+
+- **Free-plan generation (funnel L2):** capture-form intake → per-client state
+  seed → a predicate-checked week of daily cards, rendered for the coach to
+  personalize and deliver by hand. The engine composes for whatever the client
+  has — mat, gym, garage, pool, outdoors (`context` + `equipment_available`
+  are data).
+- **Check-in loop (L3):** `open` (readiness) / `log` (session → next-day flag
+  decided from evidence) / weekly `review` (progress/hold/deload table the
+  coach reads before each conversation).
+- **Progression (VIP):** the engine's Rule-8 gate proposes; the coach disposes.
+
+## Boundaries
+
+Per-client data lives in private instance directories owned by the coach's
+operation — never in a repo (the engine ships an `audit.sh` firewall proving
+its own repo carries no personal data). The engine generates artifacts only:
+the coach fires every send, offer, and delivery himself.
+
+## Spec
+
+The full instance spec (intake → state mapping, funnel table, starter-pack
+plan) lives at `organvm/daily-engine:instances/rob-fitness/INTEGRATION.md`.


### PR DESCRIPTION
Names organvm/daily-engine (private) as the plan-generation machine this surface can deliver: predicate-checked free plans (funnel L2), evidence check-in loop (L3), gate-proposed/coach-disposed progressions (VIP). Doc-only; no code paths touched. Full spec lives in daily-engine:instances/rob-fitness/INTEGRATION.md.