### PR TITLE
fix(scene): half-renamed sharedGeometry crashed init — whole terminal surface was dead

### DIFF
--- a/src/OrbitalNodes.js
+++ b/src/OrbitalNodes.js
@@ -63,7 +63,7 @@ export class OrbitalNodes {
                 opacity: 0.9
             });
 
-            const node = new THREE.Mesh(sharedGeometry, material);
+            const node = new THREE.Mesh(geometry, material);
             node.userData = {
                 id: config.id,
                 label: config.label,

--- a/src/tests/orbitalnodes.test.js
+++ b/src/tests/orbitalnodes.test.js
@@ -1,0 +1,18 @@
+import { describe, it, expect } from 'vitest';
+import { OrbitalNodes } from '../OrbitalNodes.js';
+
+// Regression: a half-renamed shared-geometry variable made createNodes()
+// throw ReferenceError on every page load, which killed init() before any
+// UI listener attached — the whole terminal surface went dead on the live
+// site. Constructing against a stub scene catches that class of crash.
+describe('OrbitalNodes', () => {
+  it('creates its five navigation nodes without throwing', () => {
+    const added = [];
+    const scene = { add: (obj) => added.push(obj) };
+    const orbital = new OrbitalNodes(scene, null);
+    expect(orbital.nodes.length).toBe(5);
+    expect(added.length).toBe(5);
+    const ids = orbital.nodes.map((n) => n.userData.id);
+    expect(ids).toContain('field-ops');
+  });
+});


### PR DESCRIPTION
Found while verifying the live deploy of #155: every page load of the deployed v3 threw `ReferenceError: sharedGeometry is not defined` from `OrbitalNodes.createNodes` (a half-applied rename: declaration says `geometry`, usage said `sharedGeometry`). The exception killed `LegionCommandCenter.init()` before `setupUIListeners()`, so the 3D nodes never rendered and **no terminal could open** — the interactive surface has been dead in production.

One-line fix + a regression test that instantiates `OrbitalNodes` against a stub scene (5 nodes incl. `field-ops`, no throw). 9/9 tests green, build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)