### PR TITLE
heal(security): enforce account status on token refresh + sanitize socket messages

### DIFF
--- a/backend/controllers/authController.js
+++ b/backend/controllers/authController.js
@@ -223,6 +223,14 @@ exports.refreshToken = async (req, res, next) => {
       throw new AppError('User not found', 404, 'USER_NOT_FOUND');
     }
 
+    // A refresh token must not outlive the account's active status: a
+    // suspended / inactive / deleted user is blocked at login (see above), so
+    // the same gate must apply here or they could mint fresh access tokens
+    // indefinitely from a refresh token issued while still active.
+    if (user.status !== 'active') {
+      throw new AppError('Account is not active', 403, 'ACCOUNT_INACTIVE');
+    }
+
     // Generate new access token
     const newToken = generateToken(user);
 

--- a/backend/server.js
+++ b/backend/server.js
@@ -11,6 +11,7 @@ require('dotenv').config();
 
 const { sequelize } = require('./config/database');
 const logger = require('./utils/logger');
+const { sanitizeMessage } = require('./utils/sanitize');
 const errorHandler = require('./middleware/errorHandler');
 
 // Import routes
@@ -176,11 +177,16 @@ io.on('connection', (socket) => {
   socket.on('send_message', async (data) => {
     try {
       const { recipientId, message } = data;
+      const clean = sanitizeMessage(message);
+      if (!clean.ok) {
+        socket.emit('error', { message: 'Invalid message', code: clean.reason });
+        return;
+      }
       // Save message to database
       // Emit to recipient
       io.to(`user:${recipientId}`).emit('new_message', {
         senderId: socket.user.id,
-        message,
+        message: clean.value,
         timestamp: new Date()
       });
     } catch (error) {
@@ -198,12 +204,18 @@ io.on('connection', (socket) => {
         throw new Error('NOT_AUTHORIZED_GUILD');
       }
 
+      const clean = sanitizeMessage(message);
+      if (!clean.ok) {
+        socket.emit('error', { message: 'Invalid message', code: clean.reason });
+        return;
+      }
+
       // Save message
       // Broadcast to guild
       io.to(`guild:${guildId}`).emit('new_guild_message', {
         senderId: socket.user.id,
         username: socket.user.username,
-        message,
+        message: clean.value,
         timestamp: new Date()
       });
     } catch (error) {

--- a/backend/tests/security/messageSanitize.test.js
+++ b/backend/tests/security/messageSanitize.test.js
@@ -1,0 +1,46 @@
+const { sanitizeMessage, escapeHtml, stripControlChars } = require('../../utils/sanitize');
+
+describe('sanitizeMessage', () => {
+  it('escapes HTML so socket messages cannot inject markup/script', () => {
+    const res = sanitizeMessage('<script>alert("xss")</script>');
+    expect(res.ok).toBe(true);
+    expect(res.value).not.toContain('<script>');
+    expect(res.value).toContain('&lt;script&gt;');
+  });
+
+  it('escapes attribute-breaking characters', () => {
+    const res = sanitizeMessage(`hi" onmouseover='x'`);
+    expect(res.ok).toBe(true);
+    expect(res.value).not.toContain('"');
+    expect(res.value).not.toContain("'");
+    expect(res.value).toContain('&quot;');
+    expect(res.value).toContain('&#x27;');
+  });
+
+  it('rejects non-string payloads (type safety)', () => {
+    expect(sanitizeMessage({ evil: true }).ok).toBe(false);
+    expect(sanitizeMessage(42).ok).toBe(false);
+    expect(sanitizeMessage(null).ok).toBe(false);
+    expect(sanitizeMessage(undefined).ok).toBe(false);
+  });
+
+  it('rejects empty / whitespace-only messages', () => {
+    expect(sanitizeMessage('').ok).toBe(false);
+    expect(sanitizeMessage('    ').ok).toBe(false);
+    expect(sanitizeMessage('\u0000\u0007').ok).toBe(false);
+  });
+
+  it('caps message length to prevent broadcast DoS', () => {
+    const res = sanitizeMessage('a'.repeat(5000), { maxLength: 100 });
+    expect(res.ok).toBe(true);
+    expect(res.value.length).toBeLessThanOrEqual(100);
+  });
+
+  it('strips control characters', () => {
+    expect(stripControlChars('a\u0000b\u0007c')).toBe('abc');
+  });
+
+  it('escapeHtml is idempotent-safe on plain text', () => {
+    expect(escapeHtml('hello world')).toBe('hello world');
+  });
+});

--- a/backend/tests/security/refreshTokenStatus.test.js
+++ b/backend/tests/security/refreshTokenStatus.test.js
@@ -1,0 +1,83 @@
+const jwt = require('jsonwebtoken');
+
+jest.mock('../../utils/logger', () => ({
+  error: jest.fn(),
+  warn: jest.fn(),
+  info: jest.fn(),
+  debug: jest.fn(),
+}));
+
+jest.mock('../../models/User', () => ({
+  findByPk: jest.fn(),
+}));
+
+jest.mock('../../services/analyticsService', () => ({
+  trackEvent: jest.fn(),
+}));
+
+const User = require('../../models/User');
+const { refreshToken } = require('../../controllers/authController');
+
+const REFRESH_SECRET = 'test-refresh-secret';
+
+function mockReqResNext(body = {}) {
+  const req = { body };
+  const res = {
+    status: jest.fn().mockReturnThis(),
+    json: jest.fn().mockReturnThis(),
+  };
+  const next = jest.fn();
+  return { req, res, next };
+}
+
+describe('refreshToken account-status enforcement', () => {
+  beforeAll(() => {
+    process.env.JWT_REFRESH_SECRET = REFRESH_SECRET;
+    process.env.JWT_SECRET = 'test-secret';
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  function tokenFor(userId) {
+    return jwt.sign({ userId }, REFRESH_SECRET);
+  }
+
+  it('blocks a suspended user from refreshing their access token', async () => {
+    User.findByPk.mockResolvedValue({ id: 'u1', status: 'suspended', role: 'user' });
+    const { req, res, next } = mockReqResNext({ refreshToken: tokenFor('u1') });
+
+    await refreshToken(req, res, next);
+
+    expect(next).toHaveBeenCalledWith(
+      expect.objectContaining({ statusCode: 403, code: 'ACCOUNT_INACTIVE' })
+    );
+    expect(res.json).not.toHaveBeenCalled();
+  });
+
+  it('blocks an inactive/deleted user just like login does', async () => {
+    User.findByPk.mockResolvedValue({ id: 'u2', status: 'deleted', role: 'user' });
+    const { req, res, next } = mockReqResNext({ refreshToken: tokenFor('u2') });
+
+    await refreshToken(req, res, next);
+
+    expect(next).toHaveBeenCalledWith(
+      expect.objectContaining({ statusCode: 403, code: 'ACCOUNT_INACTIVE' })
+    );
+  });
+
+  it('still issues a new token for an active user', async () => {
+    User.findByPk.mockResolvedValue({
+      id: 'u3', status: 'active', role: 'user', email: 'a@b.c', username: 'u3',
+    });
+    const { req, res, next } = mockReqResNext({ refreshToken: tokenFor('u3') });
+
+    await refreshToken(req, res, next);
+
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ success: true, data: expect.objectContaining({ token: expect.any(String) }) })
+    );
+    expect(next).not.toHaveBeenCalled();
+  });
+});

--- a/backend/utils/sanitize.js
+++ b/backend/utils/sanitize.js
@@ -1,0 +1,61 @@
+// Shared input-sanitization helpers.
+//
+// Real-time socket messages are broadcast to other connected clients and may be
+// rendered as HTML by a receiving client, so untrusted message content must be
+// length-bounded and HTML-escaped before it leaves the server. This is the
+// distilled, server-side ideal form of the "Socket.IO XSS" / "secure socket
+// message handlers with input validation" want.
+
+const DEFAULT_MAX_MESSAGE_LENGTH = 2000;
+
+const HTML_ESCAPES = {
+  '&': '&amp;',
+  '<': '&lt;',
+  '>': '&gt;',
+  '"': '&quot;',
+  "'": '&#x27;',
+  '`': '&#x60;',
+};
+
+function escapeHtml(value) {
+  return String(value).replace(/[&<>"'`]/g, (ch) => HTML_ESCAPES[ch]);
+}
+
+// Strip ASCII control characters (except tab/newline/carriage-return) that have
+// no place in a chat message and can be used to smuggle terminal/formatting
+// escape sequences.
+function stripControlChars(value) {
+  // eslint-disable-next-line no-control-regex
+  return String(value).replace(/[\u0000-\u0008\u000B\u000C\u000E-\u001F\u007F]/g, '');
+}
+
+/**
+ * Sanitize an untrusted real-time message.
+ *
+ * @param {*} input - raw value from the socket payload
+ * @param {object} [opts]
+ * @param {number} [opts.maxLength] - hard cap on length (default 2000)
+ * @returns {{ ok: boolean, value: string, reason?: string }}
+ */
+function sanitizeMessage(input, opts = {}) {
+  const maxLength = opts.maxLength || DEFAULT_MAX_MESSAGE_LENGTH;
+
+  if (typeof input !== 'string') {
+    return { ok: false, value: '', reason: 'MESSAGE_NOT_STRING' };
+  }
+
+  const stripped = stripControlChars(input).trim();
+  if (stripped.length === 0) {
+    return { ok: false, value: '', reason: 'MESSAGE_EMPTY' };
+  }
+
+  const bounded = stripped.slice(0, maxLength);
+  return { ok: true, value: escapeHtml(bounded) };
+}
+
+module.exports = {
+  DEFAULT_MAX_MESSAGE_LENGTH,
+  escapeHtml,
+  stripControlChars,
+  sanitizeMessage,
+};


### PR DESCRIPTION
## What & why

Two **real, currently-unfixed** vulnerabilities on `main`, distilled from the runaway Jules security cluster (~40 open PRs across the priv-esc + XSS themes) into the current backend architecture — rather than merging any single stale, conflicting duplicate.

### 1. Token refresh ignored account status (privilege escalation)
`authController.login` blocks non-active users (`user.status !== 'active'` → 403), but `authController.refreshToken` did **not**: it found the user and immediately minted a new access token. A suspended/inactive/deleted user could therefore retain access indefinitely by refreshing. Fixed by applying the same status gate.

### 2. Socket messages were broadcast unsanitized (stored/reflected XSS)
`send_message` and `guild_message` broadcast raw `message` content to other clients with no validation. Added `backend/utils/sanitize.js` (HTML-escape, control-char strip, length cap, type check) and wired it into both handlers. Guild authorization behavior is unchanged.

## Tests
- `backend/tests/security/refreshTokenStatus.test.js` — suspended/deleted blocked (403 ACCOUNT_INACTIVE), active still succeeds.
- `backend/tests/security/messageSanitize.test.js` — escapes `<script>`/attr-breakers, rejects non-string & empty, caps length.
- Full backend security suite green (5 suites / 15 tests); existing auth + socketGuildAuth tests unaffected.

## Lineage (never-close doctrine)
This is the distilled ideal form of the priv-esc + XSS PR cluster; those duplicates are being engaged and marked superseded-by-this on the github-universe ledger, **not closed**.