### PR TITLE
fix(security): block privilege escalation via onboarding role mass-assignment

### DIFF
--- a/backend/controllers/gamificationController.js
+++ b/backend/controllers/gamificationController.js
@@ -401,7 +401,7 @@ exports.unlockSkill = async (req, res, next) => {
 exports.saveOnboarding = async (req, res, next) => {
   try {
     const userId = req.user.id;
-    const { role, gamificationStyle, gamificationTheme } = req.body;
+    const { gamificationStyle, gamificationTheme } = req.body;
 
     const user = await User.findByPk(userId);
 
@@ -409,8 +409,11 @@ exports.saveOnboarding = async (req, res, next) => {
       throw new AppError('User not found', 404, 'USER_NOT_FOUND');
     }
 
-    // Update user fields
-    if (role) user.role = role; // Note: In a real app, changing role might require more checks
+    // Update user fields.
+    // SECURITY: onboarding must NOT accept `role` from the request body — that
+    // is a privilege-escalation vector (any authenticated user could POST
+    // `{ role: 'admin' }` and self-promote). Onboarding only sets gamification
+    // preferences; role changes go through a separate, authorized admin path.
     if (gamificationStyle) user.gamification_style = gamificationStyle;
     if (gamificationTheme) user.gamification_theme = gamificationTheme;
     user.onboarding_completed = true;
@@ -421,7 +424,6 @@ exports.saveOnboarding = async (req, res, next) => {
       userId,
       eventType: 'onboarding_completed',
       properties: {
-        role,
         style: gamificationStyle,
         theme: gamificationTheme
       }

--- a/backend/tests/gamificationController.test.js
+++ b/backend/tests/gamificationController.test.js
@@ -376,9 +376,9 @@ describe('gamificationController', () => {
       expect(res.json).not.toHaveBeenCalled();
     });
 
-    it('persists provided preferences and marks onboarding complete', async () => {
+    it('persists provided preferences, marks onboarding complete, and ignores role from the body', async () => {
       const save = jest.fn().mockResolvedValue();
-      const user = { id: 'user-123', save };
+      const user = { id: 'user-123', role: 'user', save };
       User.findByPk.mockResolvedValueOnce(user);
       const { req, res, next } = mockReqResNext({
         body: {
@@ -391,7 +391,8 @@ describe('gamificationController', () => {
       await gamificationController.saveOnboarding(req, res, next);
 
       expect(next).not.toHaveBeenCalled();
-      expect(user.role).toBe('coach');
+      // SECURITY: role must NOT be assignable through onboarding.
+      expect(user.role).toBe('user');
       expect(user.gamification_style).toBe('competitive');
       expect(user.gamification_theme).toBe('military');
       expect(user.onboarding_completed).toBe(true);
@@ -405,7 +406,7 @@ describe('gamificationController', () => {
         data: {
           user: {
             id: 'user-123',
-            role: 'coach',
+            role: 'user',
             gamificationStyle: 'competitive',
             gamificationTheme: 'military',
             onboardingCompleted: true,

--- a/backend/tests/security/onboardingRoleEscalation.test.js
+++ b/backend/tests/security/onboardingRoleEscalation.test.js
@@ -1,0 +1,74 @@
+jest.mock('../../config/database', () => ({
+  sequelize: { query: jest.fn() },
+}));
+
+jest.mock('../../middleware/errorHandler', () => {
+  class AppError extends Error {
+    constructor(message, statusCode, code = null) {
+      super(message);
+      this.statusCode = statusCode;
+      this.code = code;
+      this.isOperational = true;
+    }
+  }
+  return { AppError };
+});
+
+jest.mock('../../models/User', () => ({
+  findByPk: jest.fn(),
+}));
+
+jest.mock('../../utils/logger', () => ({
+  error: jest.fn(), warn: jest.fn(), info: jest.fn(), debug: jest.fn(),
+}));
+
+jest.mock('../../services/analyticsService', () => ({
+  trackEvent: jest.fn(),
+}));
+
+const User = require('../../models/User');
+const { saveOnboarding } = require('../../controllers/gamificationController');
+
+function mockReqResNext(body = {}) {
+  const req = { user: { id: 'user-123' }, body };
+  const res = {
+    status: jest.fn().mockReturnThis(),
+    json: jest.fn().mockReturnThis(),
+  };
+  const next = jest.fn();
+  return { req, res, next };
+}
+
+describe('saveOnboarding privilege-escalation prevention', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('does NOT let a user promote themselves to admin via the onboarding body', async () => {
+    const user = {
+      id: 'user-123', role: 'user', save: jest.fn().mockResolvedValue(true),
+    };
+    User.findByPk.mockResolvedValue(user);
+    const { req, res, next } = mockReqResNext({ role: 'admin', gamificationStyle: 'rpg' });
+
+    await saveOnboarding(req, res, next);
+
+    expect(user.role).toBe('user');            // role untouched
+    expect(user.gamification_style).toBe('rpg'); // preferences still applied
+    expect(next).not.toHaveBeenCalled();
+    // response must not echo an escalated role
+    const payload = res.json.mock.calls[0][0];
+    expect(payload.data.user.role).toBe('user');
+  });
+
+  it('completes onboarding and persists gamification preferences', async () => {
+    const user = { id: 'user-123', role: 'user', save: jest.fn().mockResolvedValue(true) };
+    User.findByPk.mockResolvedValue(user);
+    const { req, res } = mockReqResNext({ gamificationStyle: 'military', gamificationTheme: 'dark' });
+
+    await saveOnboarding(req, res, jest.fn());
+
+    expect(user.gamification_style).toBe('military');
+    expect(user.gamification_theme).toBe('dark');
+    expect(user.onboarding_completed).toBe(true);
+    expect(user.save).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Critical: self-service admin escalation on `main`

`gamificationController.saveOnboarding` read `role` from the request body and assigned it directly:

```js
const { role, gamificationStyle, gamificationTheme } = req.body;
...
if (role) user.role = role; // Note: In a real app, changing role might require more checks
```

Any authenticated user could `POST /api/v1/users/onboarding` with `{ "role": "admin" }` and self-promote. The inline comment already flagged the risk; the fix was never landed.

### Fix
- `saveOnboarding` no longer reads or writes `role` — it sets only `gamification_style`, `gamification_theme`, and `onboarding_completed`. Role changes belong on a separate authorized admin path.

### Tests
- New `backend/tests/security/onboardingRoleEscalation.test.js`: `{ role: 'admin' }` in the body leaves `user.role` unchanged; preferences still persist.
- Updated the pre-existing onboarding test (it asserted the *vulnerable* behavior) to assert role is ignored.
- Backend security + gamification + auth suites green (8 suites / 57 tests).

## Lineage (never-close doctrine)
Distilled ideal form of the Sentinel 'privilege escalation in onboarding' cluster (#47/#67/#80/#94/#100/#111); those duplicates are engaged + marked superseded-by-this on the github-universe ledger, **not closed**.